### PR TITLE
Persist authToken from server to local storage

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,4 +1,5 @@
 import { createAction } from './createAction';
+import { storeAuthToken, destroyAuthToken, getAuthToken } from '../api/utils';
 
 export const authActionTypes = {
   AUTH_LOGIN: 'AUTH_LOGIN',
@@ -7,7 +8,21 @@ export const authActionTypes = {
 
   AUTH_REGISTER: 'AUTH_REGISTER',
   AUTH_REGISTER_SUCCESS: 'AUTH_REGISTER_SUCCESS',
-  AUTH_REGISTER_FAILURE: 'AUTH_REGISTER_FAILURE'
+  AUTH_REGISTER_FAILURE: 'AUTH_REGISTER_FAILURE',
+
+  AUTH_PERSIST_TOKEN: 'AUTH_PERSIST_TOKEN',
+  AUTH_PERSIST_TOKEN_SUCCESS: 'AUTH_PERSIST_TOKEN_SUCCESS',
+  AUTH_PERSIST_TOKEN_FAILURE: 'AUTH_PERSIST_TOKEN_FAILURE',
+
+  AUTH_LOGOUT: 'AUTH_LOGOUT',
+  AUTH_LOGOUT_SUCCESS: 'AUTH_LOGOUT_SUCCESS',
+  AUTH_LOGOUT_FAILURE: 'AUTH_LOGOUT_FAILURE',
+
+  AUTH_STORE_TOKEN: 'AUTH_STORE_TOKEN',
+
+  AUTH_RETRIEVE_TOKEN: 'AUTH_RETRIEVE_TOKEN',
+  AUTH_RETRIEVE_TOKEN_SUCCESS: 'AUTH_RETRIEVE_TOKEN_SUCCESS',
+  AUTH_RETRIEVE_TOKEN_FAILURE: 'AUTH_RETRIEVE_TOKEN_FAILURE'
 }
 
 export function createAuthActions(api) {
@@ -50,9 +65,62 @@ export function createAuthActions(api) {
     }
   }
 
+  function storeToken(userId, authToken) {
+    return dispatch => {
+      dispatch(createAction(authActionTypes.AUTH_STORE_TOKEN, {userId, authToken}))
+    }
+  }
+
+  function persistAuthToken(userId, authToken) {
+    return dispatch => {
+      dispatch(createAction(authActionTypes.AUTH_PERSIST_TOKEN, {userId, authToken}))
+      return storeAuthToken(userId, authToken)
+        .then(() => {
+          dispatch(createAction(authActionTypes.AUTH_PERSIST_TOKEN_SUCCESS, {userId, authToken}))
+        })
+        .catch(err => {
+          dispatch(createAction(authActionTypes.AUTH_PERSIST_TOKEN_FAILURE, {err}))
+          throw err
+        })
+    }
+  }
+
+  function retrieveAuthToken() {
+    return dispatch => {
+      dispatch(createAction(authActionTypes.AUTH_RETRIEVE_TOKEN))
+      return getAuthToken()
+        .then(data => {
+          dispatch(createAction(authActionTypes.AUTH_RETRIEVE_TOKEN_SUCCESS, data))
+          return data
+        })
+        .catch(err => {
+          dispatch(createAction(authActionTypes.AUTH_RETRIEVE_TOKEN_FAILURE, {err}))
+          throw err
+        })
+    }
+  }
+
+  function logout() {
+    return dispatch => {
+      dispatch(createAction(authActionTypes.AUTH_LOGOUT))
+      return destroyAuthToken()
+        .then(() => {
+          dispatch(createAction(authActionTypes.AUTH_LOGOUT_SUCCESS))
+        })
+        .catch(err => {
+          dispatch(createAction(authActionTypes.AUTH_LOGOUT_FAILURE, {err}))
+          throw err
+        })
+    }
+  }
+
   return {
     registerUser,
     registerUserAndLogin,
-    loginAndStoreToken
+    loginAndStoreToken,
+    storeToken,
+    persistAuthToken,
+    retrieveAuthToken,
+    logout
   }
 };

--- a/src/actions/location.js
+++ b/src/actions/location.js
@@ -17,7 +17,7 @@ export function createLocationActions(api) {
       return api.updateCoords(userId, authToken, {lat, lng})
         .then(() => {
           dispatch(createAction(locationActionTypes.LOCATION_UPDATE_COORDS_SUCCESS, {userId, authToken, lat, lng}))
-          onSuccess({userId, token: authToken, lat, lng})
+          onSuccess({userId, authToken, lat, lng})
         })
         .catch(error => {
           dispatch(createAction(locationActionTypes.LOCATION_UPDATE_COORDS_FAILURE, {userId, error}))

--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -26,7 +26,7 @@ export default class Api {
     );
   };
 
-  getUser(userId, authToken) {
+  getUser(userId) {
     return fetchRequest(
       this.apiUrl,
       `users/${userId}`,

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,4 +1,5 @@
 import ApiError from './ApiError'
+import { AsyncStorage } from 'react-native';
 
 function processJson(responseJson, response) {
   const error = responseJson.error || displayableErrors(responseJson.errors);
@@ -30,7 +31,7 @@ export function handleIfApiError(error, handler) {
   throw error;
 };
 
-export function fetchRequest(apiUrl, route, request, body, token) {
+export function fetchRequest(apiUrl, route, request, body, authToken) {
   const headers = {
     'Content-Type': 'application/json',
     Accept: '*/*'
@@ -39,7 +40,7 @@ export function fetchRequest(apiUrl, route, request, body, token) {
   return fetch(apiUrl + route, {
     body: body ? JSON.stringify(body) : null,
     headers: new Headers(
-      token ? {...headers, 'Authorization': token} : headers
+      authToken ? {...headers, 'Authorization': authToken} : headers
     ),
     credentials: 'include',
     ...request
@@ -79,3 +80,24 @@ export function secureImageSource(imageSource) {
 export function maybePermissionsError(error) {
   return (error || '').toLowerCase().indexOf('permission') >= 0;
 };
+
+export function storeAuthToken(userId, authToken) {
+  return AsyncStorage.multiSet([['userId', String(userId)], ['authToken', authToken]]);
+}
+
+export function getAuthToken() {
+  return new Promise((resolve, reject) => {
+    return AsyncStorage.multiGet(['userId', 'authToken'])
+      .then((vals) => {
+        const userId = vals[0][1] ? parseInt(vals[0][1]) : undefined
+        const authToken = vals[1][1]
+
+        resolve({ userId, authToken })
+      })
+      .catch(reject)
+  })
+}
+
+export function destroyAuthToken() {
+  return AsyncStorage.multiRemove(['userId', 'authToken']);
+}

--- a/src/components/register/FinishRegistration.js
+++ b/src/components/register/FinishRegistration.js
@@ -127,6 +127,14 @@ export default class FinishRegistration extends Component {
             </View>
           </View>
 
+          <View>
+            <TouchableHighlight style={globalStyles.actionButton} onPress={this.props.logout}>
+              <Text style={globalStyles.actionButtonText}>
+                LOGOUT
+              </Text>
+            </TouchableHighlight>
+          </View>
+
         </View>
       </View>
     )

--- a/src/containers/register/FinishRegistrationContainer.js
+++ b/src/containers/register/FinishRegistrationContainer.js
@@ -24,13 +24,13 @@ class FinishRegistrationContainer extends Component {
 
   upload = (imageSource) => {
     const { auth, screenProps, dispatch } = this.props;
-    const { userId, token } = auth;
+    const { userId, authToken } = auth;
     const { actions } = screenProps;
 
     this.setState({ inProgress: true }, () => {
-      dispatch(actions.photo.uploadAndCreateProfilePhoto(userId, token, imageSource))
+      dispatch(actions.photo.uploadAndCreateProfilePhoto(userId, authToken, imageSource))
         .then(() => {
-          return dispatch(actions.user.getUser(userId, token))
+          return dispatch(actions.user.getUser(userId, authToken))
         })
         .then(() => {
           this.setState({ inProgress: false, isPhotoUploaded: true })
@@ -43,8 +43,16 @@ class FinishRegistrationContainer extends Component {
     })
   }
 
+  logout = () => {
+    const { dispatch, navigation } = this.props
+    const { actions } = this.props.screenProps;
+
+    dispatch(actions.auth.logout())
+      .then(() => navigation.navigate('Login'))
+  }
+
   render() {
-    const { auth, userMeta, hasLocationEnabled } = this.props;
+    const { auth, userMeta, hasLocationEnabled, screenProps } = this.props;
     const { inProgress, error, isPhotoUploaded } = this.state;
 
     const currentUser = userMeta[auth.userId];
@@ -60,6 +68,7 @@ class FinishRegistrationContainer extends Component {
         uploadedPhoto={currentUser.photo}
         apiError={displayableError(error)}
         userFirstName={currentUser.firstName}
+        logout={this.logout}
       />
     );
   };

--- a/src/containers/register/RegisterContainer.js
+++ b/src/containers/register/RegisterContainer.js
@@ -37,13 +37,13 @@ class RegisterContainer extends Component {
 
     this.setState({inProgress: true}, () => {
       dispatch(actions.auth.registerUserAndLogin(firstName, lastName, email, username, password))
-        .then(({ userId, token }) => {
-          return dispatch(actions.location.getCoordsAndUpdate(userId, token))
+        .then(({ userId, authToken }) => {
+          return dispatch(actions.location.getCoordsAndUpdate(userId, authToken))
             .then(this.getUserAndFinishRegistration)
             .catch(() => {
               this.setState(
                 { hasLocationEnabled: false },
-                () => this.getUserAndFinishRegistration({ userId, token })
+                () => this.getUserAndFinishRegistration({ userId, authToken })
               )
             })
         })
@@ -51,11 +51,11 @@ class RegisterContainer extends Component {
     });
   };
 
-  getUserAndFinishRegistration = ({ userId, token }) => {
+  getUserAndFinishRegistration = ({ userId, authToken }) => {
     const { dispatch, screenProps } = this.props;
     const { actions } = screenProps;
 
-    return dispatch(actions.user.getUser(userId, token))
+    return dispatch(actions.user.getUser(userId, authToken))
       .then(this.handleRegisterSuccess)
       .catch(this.handleError);
   }

--- a/src/middleware/userMiddleware.js
+++ b/src/middleware/userMiddleware.js
@@ -5,6 +5,7 @@ import { locationActionTypes } from '../actions/location';
 export function createUserMiddleware(actions) {
   const userActions = actions.user;
   const locationActions = actions.location;
+  const authActions = actions.auth;
 
   function userMiddleware(store) {
     const { dispatch } = store;
@@ -13,11 +14,7 @@ export function createUserMiddleware(actions) {
 
       switch (action.type) {
         case authActionTypes.AUTH_LOGIN_SUCCESS:
-          // dispatch(locationActions.getCoordsAndUpdate(action.userId, action.token));
-          return;
-
-        case locationActionTypes.LOCATION_UPDATE_COORDS_SUCCESS:
-          // dispatch(userActions.getUser(action.userId, action.authToken));
+          dispatch(authActions.persistAuthToken(action.userId, action.token))
           return;
 
         default:

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,6 +1,6 @@
 import { authActionTypes } from '../actions/auth';
 const initialState = {
-  token: null,
+  authToken: null,
   userId: null
 }
 
@@ -9,7 +9,10 @@ export default function auth(state = initialState, action) {
     case authActionTypes.AUTH_LOGIN_SUCCESS:
       const { userId, token } = action;
 
-      return Object.assign({}, state, { userId, token });
+      return Object.assign({}, state, { userId, authToken: token });
+
+    case authActionTypes.AUTH_STORE_TOKEN:
+      return Object.assign({}, state, { userId: action.userId, authToken: action.authToken })
 
     default:
       return state;


### PR DESCRIPTION
- storeAuthToken, getAuthToken, and destroyAuthToken helper fn's (usi…ng AsyncStorage) in api/utils
- storeToken, persistToken, and logout actions in auth
- middleware to persistToken on successful login
- LoginContainer to check for existence of token on launch, redirect to FinishRegistration if so
- change all instances of 'token' reference to 'authToken'